### PR TITLE
Allows to use dynamic function names

### DIFF
--- a/tslint-base.json
+++ b/tslint-base.json
@@ -19,7 +19,7 @@
       true,
       {
         "static-method-regex": "^[a-z][\\w\\d]+$",
-        "function-regex": "^([a-z][\\w\\d]+)|(([A-Z][\\w\\d]+)Mixin)$"
+        "function-regex": "^([a-z][\\w\\d]+)|(\\[[a-z][\\w\\d]+\\])|(([A-Z][\\w\\d]+)Mixin)$"
       }
     ],
     "member-ordering": [


### PR DESCRIPTION
Allows to use variables to set function names, including symbols. Useful to mock private members in mixins or to get unoverridable functions.